### PR TITLE
add Usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 ```
 pip install percol
-gem install inifile
-gem install aws-sdk
+gem install inifile aws-sdk
 ```
 
 - copy files to somewhere in exec path
@@ -16,4 +15,18 @@ gem install aws-sdk
 git clone git@github.com:sumikawa/ec2ssh.git
 cd ec2ssh
 cp ec2ssh get_instances.rb /usr/local/bin/
+```
+
+## Usage
+
+- add your private key file to ssh-agent
+
+```
+ssh-add ~/.ssh/<YOUR_PRIVATE_KEY>.pem
+```
+
+- run ec2ssh and select an instance you want to log in to
+
+```
+ec2ssh
 ```


### PR DESCRIPTION
It's required to run `ssh-add` before using `ec2ssh` because `ec2ssh` uses `ssh -A`.
I think this step should be documented so I want to add it.
