### PR TITLE
Improve caching performance

### DIFF
--- a/get_instances.rb
+++ b/get_instances.rb
@@ -6,14 +6,17 @@ require 'inifile'
 require 'optparse'
 require 'yaml'
 
-CACHE = "#{Dir.home}/.ec2ssh"
+CONFIG = File.join(Dir.home, '.aws', 'config').freeze
+CACHE = File.join(Dir.home, '.ec2ssh').freeze
+CACHE_TTL = 3600
+INSTANCE = Struct.new(:instance_id, :public_dns_name, :private_dns_name, :tags)
 
 profile = 'default'
-$opt = {}
+opts = {}
 OptionParser.new do |opt|
   opt.banner = "Usage: #{opt.program_name} [options]"
   opt.on('-h', '--help', 'Show usage') { puts opt.help ; exit }
-  opt.on('-f', '--flush', 'Flush cache') { $opt[:ignore] = true }
+  opt.on('-f', '--flush', 'Flush cache') { opts[:ignore] = true }
   opt.on('-p PROFILE', '--profile PROFILE', 'Specify profile') { |v|
     profile = "profile #{v}"
     Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: profile)
@@ -21,47 +24,43 @@ OptionParser.new do |opt|
   opt.parse!(ARGV)
 end
 
-ini = IniFile.load(File.expand_path("~/.aws/config"))
+ini = IniFile.load(CONFIG)
 region = ENV['REGION'] || ini[profile]['region']
 Aws.config[:region] = region
 
-instances = nil
+instances = []
 # load cache if fresh
-instances = nil
-if File.exist?(CACHE) && $opt[:ignore].nil? then
+if File.exist?(CACHE) && opts[:ignore].nil?
   mtime = File::Stat.new(CACHE).mtime
-  if Time.now - mtime < 3600 then
+  if Time.now - mtime < CACHE_TTL
     cache = YAML.load_file(CACHE)
     instances = cache[profile][region] rescue nil
   end
 end
 
-if instances.nil? then
+if instances.empty?
   ec2 = Aws::EC2::Client.new
-  instances = ec2.describe_instances.reservations
-  File::open(CACHE, "w") { |f|
-    cache = {}
-    cache[profile] = {}
-    cache[profile][region] = instances
+  instances = ec2.describe_instances(
+    filters: [{ name: 'instance-state-name', values: ['running'] }]
+  ).reservations.flat_map(&:instances).map! do |instance|
+    INSTANCE.new(instance.instance_id,
+                 instance.public_dns_name,
+                 instance.private_dns_name,
+                 instance.tags)
+  end
+  File.open(CACHE, 'w') { |f|
+    cache = { profile => { region => instances } }
     YAML.dump(cache, f)
   }
 end
 
-if instances
-  instances.each do |reservation|
-    reservation.instances.each do |instance|
-      next unless instance.state.name == "running"
-      user = "ec2-user"
-      name = instance.instance_id
-      dnsname = instance.public_dns_name
-      if dnsname == nil
-        dnsname = instance.private_dns_name
-      end
-      instance.tags.each do |tag|
-        name = tag.value if tag.key =~ /^name/i
-        user = tag.value if tag.key =~ /^user/i
-      end
-      puts "\"#{name}\"\t#{user}@#{dnsname}\t#{instance.instance_id}"
-    end
+instances.each do |instance|
+  user = 'ec2-user'
+  name = instance.instance_id
+  dnsname = instance.public_dns_name || instance.private_dns_name
+  instance.tags.each do |tag|
+    name = tag.value if tag.key =~ /^name/i
+    user = tag.value if tag.key =~ /^user/i
   end
+  puts "\"#{name}\"\t#{user}@#{dnsname}\t#{instance.instance_id}"
 end


### PR DESCRIPTION
# Problem

Currently this script fetches information of all instances and saves all of it as-is to a cache file with conversion to YAML.
Since each instance's object has a lot of unnecessary data for this script (e.g. information of block devices and network interfaces), the current cache file size seems to be large and I believe this causes slower performance on reading from and writing into it.
# Solution

I suggest the following two improvements:
1. Fetch only `running` instances (exclude `stopped` and `terminated` instances) by using `filters` option on `Aws::EC2::Client#describe_instances`
2. Create our own cache objects (`INSTANCE` struct in the code) that hold only necessary data for this script, and save them as cache instead.
# Benchmark

I measured benchmarks in my case with `du` command and `benchmark-ips` gem.
My instances in ap-northeast-1 were 10 running and 5 stopped at that time.
## Current
### File size

```
$ du ~/.ec2ssh
72K     /Users/skatsuta/.ec2ssh
```
### Performance in case of using cache

```
36.173  (± 8.3%) i/s -    180.000  in   5.003348s
```
## This PR
### File size

```
$ du ~/.ec2ssh
8.0K    /Users/skatsuta/.ec2ssh
```

Reduced to 1/9.
### Performance in case of using cache

```
286.884  (± 8.0%) i/s -      1.428k in   5.014516s
```

About **7.9x faster**! ;)
# Other changes

Other minor changes are also added in this PR.
- Use `File.join` in order to build file paths more generally
- Define cache TTL as a constant
- Not use a global variable
- Refactor redundant code
# If you encounter an error...

Try refreshing a cache with the command below:

```
$ ec2ssh -f
```

This will refresh a cache with the new cache data format.
